### PR TITLE
fix(webgl): pin Rust to 1.86.0 to avoid Unity wasm-opt incompatibility

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [target.wasm32-unknown-emscripten]
-rustflags = [
-    "-C",
-    "target-feature=-bulk-memory,-bulk-memory-opt,-call-indirect-overlong",
-]
+# Defense-in-depth: explicitly disable `bulk-memory` so a future Rust
+# toolchain bump cannot silently re-enable it and break Unity WebGL linking.
+# See rust-toolchain.toml for why this matters.
+rustflags = ["-C", "target-feature=-bulk-memory"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '.cargo/config.toml') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '.cargo/config.toml', 'rust-toolchain.toml') }}
 
       - name: Build macOS Universal
         run: |
@@ -82,7 +82,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '.cargo/config.toml') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '.cargo/config.toml', 'rust-toolchain.toml') }}
 
       - name: Build Windows DLL
         run: |
@@ -121,7 +121,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '.cargo/config.toml') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '.cargo/config.toml', 'rust-toolchain.toml') }}
 
       - name: Build Linux
         run: |
@@ -182,7 +182,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-webgl-cargo-${{ hashFiles('**/Cargo.lock', '.cargo/config.toml') }}
+          key: ${{ runner.os }}-webgl-cargo-${{ hashFiles('**/Cargo.lock', '.cargo/config.toml', 'rust-toolchain.toml') }}
 
       - name: Build WebGL
         run: |

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,18 @@
+[toolchain]
+# Pinned to 1.86.0: Rust 1.87+ enables `bulk-memory` by default for
+# wasm32-unknown-emscripten, which Unity 6's bundled wasm-opt (v112)
+# does not support (`--enable-bulk-memory-opt` is unknown).
+channel = "1.86.0"
+targets = [
+    "wasm32-unknown-emscripten",
+    "aarch64-apple-darwin",
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+    "x86_64-apple-ios",
+    "aarch64-apple-ios-sim",
+    "x86_64-pc-windows-msvc",
+    "x86_64-unknown-linux-gnu",
+    "aarch64-linux-android",
+    "armv7-linux-androideabi",
+    "x86_64-linux-android",
+]


### PR DESCRIPTION
## Summary

- Pin Rust toolchain to **1.86.0** via a new `rust-toolchain.toml`.
- Clean up `.cargo/config.toml`: remove invalid target-feature entries, keep `-bulk-memory` as defense-in-depth.
- Update CI cache keys so a future toolchain bump invalidates the cache automatically.

## Problem

Unity WebGL build fails in the `build.js` linking step with:

```
Unknown option '--enable-bulk-memory-opt'
Unity's wasm-opt version does not support enable-bulk-memory-opt flag.
```

## Root Cause

- **Rust 1.87+** enables the `bulk-memory` target feature **by default** for `wasm32-unknown-emscripten`.
- The feature is baked into rustup's precompiled `std`, so `target-feature=-bulk-memory` in the user crate does **not** strip it from the archive.
- `target_features` sections in the `.a` propagate through linking. Emscripten detects them and passes `--enable-bulk-memory-opt` to `wasm-opt`.
- Unity 6000.3.11f1 ships **Binaryen wasm-opt v112**, which does not recognize that flag (it was added in Binaryen ~v116).

Additionally, the previous `.cargo/config.toml` listed `-bulk-memory-opt` and `-call-indirect-overlong` as target-features, but those are **wasm-opt pass names**, not valid Rust target-features — they were silent no-ops.

## Fix

Pin to Rust **1.86.0**, the last release before the default-features flip. This is a stable toolchain, reversible, and requires no nightly features (unlike the `-Zbuild-std` alternative).

## Alternatives Considered

- `-Zbuild-std=panic_abort,std` with `target-cpu=mvp` on nightly — cleaner long-term but requires nightly.
- Replacing Unity's bundled `wasm-opt` with Binaryen v116+ — works locally but breaks on every Unity upgrade and cannot be enforced in CI on other machines.
- Waiting for a Unity patch — Unity 6000.3.12 release notes contain no fix.

## Test plan

- [ ] Local: `rustup toolchain install 1.86.0`, `cargo clean`, rebuild WebGL via `build_all.sh webgl`.
- [ ] Unity WebGL build completes past the `build.js` linking step.
- [ ] CI: all 4 jobs (macOS+iOS / Windows / Linux+Android / WebGL) pass on the pinned toolchain.
- [ ] Cache key change confirmed — first CI run on this branch misses cache, subsequent runs hit it.

## References

- [Unity Discussions thread](https://discussions.unity.com/t/webgl-build-error-unknown-option-enable-bulk-memory-opt/1694570)
- [rust-lang/rust#141048 — wasm32 default features changed](https://github.com/rust-lang/rust/issues/141048)
- [PyO3/maturin#2549 — same issue from the Python WASM side](https://github.com/PyO3/maturin/issues/2549)

🤖 Generated with [Claude Code](https://claude.com/claude-code)